### PR TITLE
Update toolkit code section and document pipeline (Issue #46)

### DIFF
--- a/code/code.tex
+++ b/code/code.tex
@@ -1,147 +1,86 @@
-\chapter{Kod źródłowy}
+\chapter{Kod źródłowy i Potok Przetwarzania (Pipeline)}
 
 Struktura kodu źródłowego została zaprojektowana w sposób modularny, co pozwala
-na separację logiki przetwarzania sygnałów, ekstrakcji cech oraz wizualizacji rezultatów.
-Całość implementacji podzielono na trzy główne segmenty funkcjonalne.
+na ścisłą separację logiki przetwarzania sygnałów, ekstrakcji cech oraz wizualizacji rezultatów.
+Całość implementacji opiera się na spójnym potoku przetwarzania danych (ang. \textit{pipeline}), 
+od surowych odczytów z sensorów, aż po gotowe wektory cech i ich analizę.
 
 \section{Przepływ sterowania w projekcie}
-	Poniżej umieszczona jest wizualizacja przepływu danych przy wywoływaniu
-	poszczególnych skryptów:	
-	\includegraphics[width=\linewidth]{flowchart.png}
+Przepływ danych opiera się na liniowej sekwencji przetwarzania, w której wyjście
+jednego etapu staje się wejściem kolejnego. Wizualizacja przepływu danych prezentuje się następująco:
+% Zaktualizowano odniesienie do diagramu
+\begin{figure}[H]
+    \centering
+    \includegraphics[width=0.8\linewidth]{flowchart.png}
+    \caption{Architektura potoku przetwarzania danych (Pipeline)}
+    \label{fig:pipeline_flowchart}
+\end{figure}
 
-\section{Architektura systemu}
-Kod realizuje pełny potok przetwarzania danych (pipeline) – od surowych odczytów
-z sensorów kamizelki, aż po wizualizację wyników klasyfikacji. Główne moduły to:
+Główny przepływ realizowany jest poprzez następujące po sobie etapy: 
+\texttt{main} $\rightarrow$ \texttt{data\_processing} $\rightarrow$ \texttt{konwersja} $\rightarrow$ \texttt{segmentacja} $\rightarrow$ \texttt{ekstrakcja\_cech}.
 
+Poniżej szczegółowo opisano każdy z etapów zgodnie z najlepszymi praktykami dokumentacji technicznej.
+
+\section{Etap 1: Inicjalizacja i Sterowanie (\texttt{main})}
+\textbf{Nazwa modułu/funkcji:} \texttt{main()} \\
+\textbf{Ogólna idea:} Punkt wejściowy aplikacji. Odpowiada za orkiestrację całego procesu, inicjalizację połączeń (np. z bazą danych lub systemem plików) oraz sekwencyjne wywoływanie kolejnych etapów potoku przetwarzania. \\
+\textbf{Wejście:} Parametry konfiguracyjne (ścieżki do archiwów ZIP, flagi sterujące, dane dostępowe do API). \\
+\textbf{Wyjście:} Wywołanie procedur przetwarzających i przekazanie im uchwytów do danych (np. obiekty \texttt{MeasurementDatasetHook}).
+
+\section{Etap 2: Przetwarzanie danych (\texttt{data\_processing})}
+\textbf{Nazwa modułu/funkcji:} \texttt{process\_file()} / \texttt{data\_processing()} \\
+\textbf{Ogólna idea:} Moduł odpowiedzialny za wczytanie surowych plików JSONL z archiwum, przeprowadzenie wstępnego czyszczenia (obsługa brakujących wartości) i przygotowanie struktury \texttt{ADC\_data}, która przechowuje znormalizowane wyniki pomiarów w woltach. Realizuje też podstawową filtrację (np. \texttt{outlier\_detection()}) w celu usunięcia szumów i anomalii pomiarowych. \\
+\textbf{Wejście:} Surowe pliki pomiarowe w formacie JSONL pobrane z API lub archiwum lokalnego. \\
+\textbf{Wyjście:} Ustrukturyzowany, ciągły sygnał czasowy oczyszczony z największych artefaktów.
+
+\section{Etap 3: Konwersja sygnału (\texttt{konwersja})}
+\textbf{Nazwa modułu/funkcji:} \texttt{convert\_signal()} / \texttt{breath\_separation()} \\
+\textbf{Ogólna idea:} Analiza lokalnych ekstremów ciągłego sygnału w celu jego podziału na pojedyncze cykle oddechowe. Sygnał napięciowy jest rzutowany na fizyczne wartości oddychania, a faza wdechu i wydechu zostaje precyzyjnie oznaczona. \\
+\textbf{Wejście:} Oczyszczony, ciągły sygnał czasowy (wynik etapu \texttt{data\_processing}). \\
+\textbf{Wyjście:} Zbiór oznaczonych, pojedynczych cykli oddechowych (fale).
+
+\section{Etap 4: Segmentacja (\texttt{segmentacja})}
+\textbf{Nazwa modułu/funkcji:} \texttt{split\_data\_into\_segments()} \\
+\textbf{Ogólna idea:} Dzielenie ciągłego sygnału na stałe, 2-minutowe okna (segmenty) umożliwiające analizę statystyczną i ujednolicenie danych wejściowych dla algorytmów klasyfikacji. Segmenty o utracie danych przekraczającej próg (np. 20\%) są odrzucane. Długość próbek wewnątrz segmentów jest normalizowana (resampling). \\
+\textbf{Wejście:} Wyodrębnione cykle oddechowe. \\
+\textbf{Wyjście:} Pakiety (segmenty) znormalizowanych danych gotowe do bezpośredniej ekstrakcji cech.
+
+\section{Etap 5: Ekstrakcja cech (\texttt{ekstrakcja\_cech})}
+\textbf{Nazwa modułu/funkcji:} \texttt{basic\_feature\_extraction()} / Skrypt \texttt{extract\_features} \\
+\textbf{Ogólna idea:} Przekształcenie sygnału w dziedzinie czasu w niskowymiarowy wektor cech (np. BPM, głębokość oddechu, czas trwania fazy wdechu/wydechu). Funkcja jest wywoływana pojedynczo dla każdego zaakceptowanego segmentu sygnału. \\
+\textbf{Wejście:} Znormalizowane segmenty sygnału (wynik etapu \texttt{segmentacja}). \\
+\textbf{Wyjście:} Macierz cech (wektory cech) zapisana do pliku (np. \texttt{extracted\_features.jsonl}), stanowiąca bezpośrednie wejście dla modeli uczenia maszynowego.
+
+\section{Moduły Analizy i Wizualizacji}
+
+Poza głównym potokiem przetwarzania, system implementuje narzędzia badawcze i ewaluacyjne:
+
+\subsection{Tworzenie profili oddechowych (\texttt{create\_data\_profiles})}
+Odpowiada za tworzenie indywidualnych profili oddechowych (modele referencyjne). Zwraca mapę zawierającą najbardziej reprezentatywny sygnał dla danej osoby, z uwzględnieniem \texttt{timestamps}, \texttt{inhale}, \texttt{exhale}, \texttt{length} oraz \texttt{depth}. Wykorzystuje funkcję \texttt{get\_mode\_breath()} do wyłonienia dominanty oddechowej.
+
+\subsection{Wizualizacja danych i redukcja wymiarowości (\texttt{visualize\_data})}
+Moduł ładuje wyekstrahowane cechy (struktura \texttt{FeatureData}) i aplikuje na nich algorytmy redukcji wymiarowości:
 \begin{itemize}
-    \item \textbf{Przetwarzanie wejścia (Input Processing):}
-        Obsługa plików JSONL, czyszczenie danych (anomalie), wygładzanie spline-ami oraz 
-        segmentacja na 2-minutowe interwały.
-    \item \textbf{Wykrywanie cech (Feature Extraction):} 
-        Przekształcenie sygnału czasowego na wektory cech (np. BPM, głębokość oddechu, fazy oddechu).
-    \item \textbf{Wizualizacja danych:} 
-        Implementacja algorytmów redukcji wymiarowości (PCA, MDS)
-        oraz ewaluacja separowalności klas przy użyciu SVM.
-     \item \textbf{Utworzenie połączenia oraz obsługa zapytań do API:} Warstwa interakcji z BRICS API w celu przesyłu oraz odbioru wyników przetwarzania pomiaru
-     \item \textbf{Interakcja z archiwami pomiarów:} Warstwa do wydobycia pobranych pomiarów w celu ich dalszego przetwarzania
+    \item \textbf{PCA (\texttt{PCA\_algorithm})} - analiza głównych składowych.
+    \item \textbf{MDS (\texttt{MDS\_algorithm})} - wielowymiarowe skalowanie do celów wizualnych.
+\end{itemize}
+Moduł posiada także \texttt{SVM\_validation} służącą do wstępnej weryfikacji liniowej separowalności danych na płaszczyźnie, oraz metodę \texttt{plotheatmap} do wizualizacji cech po standaryzacji do przedziału $[0,1]$.
+
+\section{Komunikacja z Infrastrukturą Zewnętrzną}
+
+\subsection{Obsługa zapytań API (\texttt{DatabaseHandler})}
+Klasa \texttt{DatabaseHandler} służy jako warstwa abstrakcji (Data Access Layer) przy wymianie informacji z BRICS API. Implementuje wzorzec CRUD:
+\begin{itemize}
+	\item \texttt{upload\_measurement()}: Zapis nowego pomiaru oraz metadanych do bazy w chmurze.
+	\item \texttt{download\_measurement()}: Pobieranie zasobów po unikalnym identyfikatorze lub zestawie filtrów.
+	\item \texttt{delete\_measurement()}: Przesłanie żądania usunięcia.
 \end{itemize}
 
-\section{Kluczowe funkcje i przepływ danych wewnątrz skryptu \textnormal{\texttt{main}}}
-Przepływ danych opiera się na klasie \texttt{ADC\_data}, która przechowuje
-obrabiane dane na różnych etapach przetworzenia, w tym znormalizowane
-wyniki pomiarów w woltach. Poniżej przedstawiono kluczowe funkcje procesowe:
-
-\begin{enumerate}
-    \item \texttt{process\_file()} oraz \texttt{handle\_input\_data()}: 
-        Odpowiadają za parsowanie surowego formatu JSON (zawierającego dane z akcelerometrów
-        IMU i tensometrów ADC) do ustandaryzowanych obiektów procesowych.
-    \item \texttt{breath\_separation()}: 
-        Wykorzystuje analizę ekstremów lokalnych do podziału ciągłego sygnału na
-        pojedyncze cykle oddechowe.
-    \item \texttt{outlier\_detection()}: 
-        Realizuje filtrację statystyczną, usuwając $x\%$ oddechów o najbardziej 
-        odbiegających parametrach czasowo-amplitudowych, co minimalizuje wpływ błędów pomiarowych.
-    \item \texttt{split\_data\_into\_segments()}: 
-        Normalizuje długość próbek poprzez resampling i dzieli sygnał na fragmenty
-        ułatwiające dalszą analizę statystyczną.
-\end{enumerate}
-
-\section{Kluczowe funkcje i przepływ danych wewnątrz skryptu \textnormal{\texttt{extract\_features}}}
-Skrypt ten odpowiada za wyznaczenie wektorów cech dla segmentów oczyszczonego sygnału stanowiącego wyjście
-poprzedniego skryptu. Realizuje on to przez wybranie segmentów, których procent utraconych danych nie
-przekroczył wartości \texttt{ACCEPTABLE\_DATA\_LOSS} ustawionej bazowo na 0.2
-
-\begin{itemize}
-    \item \texttt{basic\_feature\_extraction()}: Funkcja, w której środku następuje ekstrakcja wektora cech.
-    Jest ona wywoływana pojedynczo, dla każdego segmentu analizowanego przez skrypt (mniej niż 20\% utraty danych).
-    Procedury wykonywane w ramach tej funkcji zostały opisane w sekcji \ref{subsection:extraction}.
-\end{itemize}
-
-\section{Kluczowe funkcje i przepływ danych wewnątrz skryptu \textnormal{\texttt{visualize\_data}}}
-Skrypt ten odpowiada za wizualizację danych po przetworzeniu i ekstrakcji cech. Kluczowe funkcje i elementy
-stanowiące część wizualizacji to:
-\begin{itemize}
-    \item \texttt{NO\_OF\_FEATURES\_AFTER\_ALG}:
-        Stała mówiąca o tym, do ilu cech należy zredukować nasze wektory.
-    \item \texttt{FeatureData}:
-        Struktura trzymająca dane zarówno przed, jak i po redukcji cech, etykiety dla danych
-        oraz kolory do wizualizacji.
-    \item \texttt{feature\_loading}: Funkcja zajmująca się wczytaniem wektorów cech z pliku \texttt{extracted\_features.jsonl}
-        do wyżej wspomnianej struktury.
-    \item \texttt{MDS\_algorithm}:
-        Funkcja wywołująca algorytm redukcji cech MDS i wyświetlająca jej wynik na ekranie wraz z etykietami danych.
-    \item \texttt{PCA\_algorithm}:
-        Funkcja wywołująca algorytm redukcji cech PCA i zapisująca wynik w strukturze.
-    \item \texttt{SVM\_validation}: Funkcja mająca na celu walidację możliwości podziału zbioru binarnie przez
-        hiperpłaszczyznę.
-    \item \texttt{plotheatmap}: Funkcja standaryzująca dane do przedziału [0,1] (dla każdej cechy osobno) i
-        wyświetlająca je za pomocą heatmapy.
-\end{itemize}
-
-\section{Kluczowe funkcje i przepływ danych wewnątrz skryptu \textnormal{\texttt{create\_data\_profiles}}}
-Skrypt ten odpowiada za tworzenie indywidualnych profili oddechowych każdej osobie, dla której
-zostały zebrane dane. Dzięki temu możliwe jest przedstawienie i dostrzeżenie
-indywidualnych cech oddechowych każdej osoby i wizualne potwierdzenie zasadności przeprowadzanego
-badania. Każdy taki profil jest Pythonową mapą i zawiera:
-
-\begin{itemize}
-    \item \texttt{signal}: 
-        Jest to wycinek surowego sygnału oddechowego danej osoby zawierający jeden oddech, który
-        statystycznie najlepiej reprezentuje jej sposób oddychania ze względu na szereg parametrów 
-        stanowiących kolejne pola tej mapy.
-    \item \texttt{timestamps}: 
-        Odpowiada za przechowywanie znaczników czasowych odpowiadających kolejnym punktom sygnału.
-    \item \texttt{inhale, inspiratory\_phase, exhale, expiratory\_phase}:
-        Cztery pola odpowiadające kolejnym fazom oddechu. Każde z nich zawiera różnicę w timestampach
-        pomiędzy początkiem i końcem danej fazy.
-    \item \texttt{length}:
-        Długość całego oddechu w milisekundach.
-    \item \texttt{depth}:
-        Głębokość oddechu, czyli różnica pomiędzy maksymalną a minimalną wartością sygnału
-        w danym oddechu.
-\end{itemize}
-
-Do zadań na przyszłość należy rozszerzenie tej mapy o dodatkowe pola zawierające cechy, które dokładniej pozwolą
-charakteryzować indywidualny sposób oddychania każdej osoby. Poniżej znajdują się najważniejsze funkcje
-odpowiadające za tworzenie profili oddechowych:
-
-\begin{itemize}
-    \item \texttt{create\_data\_profiles()}: 
-        Główna funkcja tworząca profile oddechowe dla każdej osoby na podstawie przetworzonych danych.
-    \item \texttt{get\_people\_list()}: 
-        Funkcja zwracająca listę osób na podstawie etykiet danych znajdujących się w folderze \texttt{results}.
-    \item \texttt{calculate\_breath\_characteristics()}: 
-        Oblicza fazy oddechu (wdech, faza inspiracji, wydech, faza ekspiracji) na podstawie sygnału dla każdego 
-        wykrytego oddechu.
-    \item \texttt{get\_mode\_breath()}:
-        Wybiera najczęściej występujący oddech na podstawie cech statystycznych.
-    \item \texttt{visualize\_profiles()}:
-        Tworzy wykresy przedstawiające profile oddechowe każdej osoby.
-\end{itemize}
-
-\section{Utworzenie połączenia oraz obsługa zapytań do API - DatabaseHandler}
-DatabaseHandler to klasa odpowiadająca za utworzenie środowiska oraz obsługę przygotowanych scenariuszy zapytań do BRICS API. Udostępnia one nastepujące metody:
-\begin{itemize}
-	\item \verb|upload_measurement()|: Wykonuje wysłanie pomiaru oraz jego metadanych do API, co w rezultacie powoduje jego zapis w bazie danych.
-	\item \verb|download_measurement()|: Daje możliwość pobrania pomiarów odpowiadających parametrom wyszukiwania.
-	\item \verb|download_measurement()|: Odpowiada za przesłanie żądania usunięcia pomiaru o danym identyfikatorze.
-\end{itemize}
-
-\section{Interakcja z archiwami pomiarów}
-MeasurementDatasetHook to klasa odpowiadająca za automatyczne wydobycie oraz udostępnienie pomiarów znajdujących się w pobranych archiwum ZIP. Dzięki implementacji wewnętrznego iteratora, możliwe jest następujące użycie klasy:
-\begin{verbatim}
-	mdh = MeasurementDatasetHook(target: raw)
-	
-	for file in mdh:
-		# procesowanie pliku z surowymi danymi
-\end{verbatim}
-
-
-% flow w funkcjach: main -> data_processing -> kolejne poniższe
-% etapy jako sekcje rozdziału kod:
-% wymagane: nazwa (funkcji)
-            %ogólna idea
-            %wejście, wyjście dla etapu
-% konwersja
-% segmentacja
-% ekstrakcja cech
+\subsection{Zarządzanie archiwalnymi zestawami danych (\texttt{MeasurementDatasetHook})}
+Narzędzie systemowe do masowego procesowania danych. Realizuje interfejs iteratora w celu automatycznego wyodrębniania pomiarów z archiwów ZIP:
+\begin{minted}{python}
+mdh = MeasurementDatasetHook(target="raw")
+for file in mdh:
+    process_file(file)
+\end{minted}
+Dzięki takiemu podejściu aplikacja nie ładuje całości danych do pamięci RAM, zachowując wysoką wydajność.


### PR DESCRIPTION
Resolves #46.

### Description
This PR entirely rewrites the toolkit code section (`code/code.tex`) to properly implement documentation best practices. It explicitly maps out the data processing pipeline, providing the inputs, outputs, and purpose of every single stage, replacing the outdated descriptions.

### Changes
- **`code/code.tex`**:
  - Generalized function descriptions to prevent them from becoming quickly outdated.
  - Formatted the pipeline into distinct stages: `main` $\rightarrow$ `data_processing` $\rightarrow$ `konwersja` $\rightarrow$ `segmentacja` $\rightarrow$ `ekstrakcja_cech`.
  - Added "Ogólna idea", "Wejście", and "Wyjście" (Idea, Input, Output) metadata definitions for each processing stage to vastly improve readability and clarity.
  - Restructured the visualization and external architecture descriptions to be modular.